### PR TITLE
Add documentation for initial endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # UCLCSSA-API OpenAPI Specification
 [![Build Status](https://travis-ci.com/UCLCSSA/UCLCSSA-API.svg?branch=master)](https://travis-ci.com/UCLCSSA/UCLCSSA-API)
-## Steps to finish
-
-1. Enable [Travis](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A) for your repository (**note**: you already have `.travis.yml` file)
-1. [Create GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/); select `public_repo` on `Select scopes` section.
-1. Use the token value as a value for [Travis environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) with the name `GH_TOKEN`
-1. Make a test commit to trigger CI: `git commit --allow-empty -m "Test Travis CI" && git push`
-1. Wait until Travis build is finished. You can check progress by clicking on the `Build Status` badge at the top
-1. **[Optional]** You can setup [custom domain](https://help.github.com/articles/using-a-custom-domain-with-github-pages/) (just create `web/CNAME` file)
-1. **[Optional]** If your API is public consider adding it into [APIs.guru](https://APIs.guru) directory using [this form](https://apis.guru/add-api/).
-1. Delete this section ❌
 
 ## Links
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -24,8 +24,6 @@ info:
 tags:
   - name: Posts
     description: Operations for user posts (could be used for post feed).
-  - name: Images
-    description: Operations for uploaded images.
 servers:
   - url: 'https://www.uclcssa.com/api'
 
@@ -49,8 +47,7 @@ paths:
           description: Starting post `id` to start fetch from (inclusive).
           required: false
           schema:
-            type: integer
-            minimum: 1
+            $ref: '#/components/schemas/Uuid'
         - name: limit
           in: query
           description: Number of posts to return starting from `id`.
@@ -86,8 +83,7 @@ paths:
           description: Target post `id`.
           required: true
           schema:
-            type: integer
-            minimum: 1
+            $ref: '#/components/schemas/Uuid'
       security:
         - main_auth:
             - 'read:post'
@@ -102,54 +98,6 @@ paths:
           description: Access forbidden
         '404':
           description: Post not found or no longer available
-
-  '/images/{id}/{timestamp}':
-    get:
-      tags:
-        - Images
-      summary: Get image by user ID and timestamp (as file name).
-      parameters:
-        - name: id
-          in: path
-          description: Image uploader (owner).
-          required: true
-          schema:
-            type: integer
-            minimum: 1
-        - name: timestamp
-          in: path
-          description: Image timestamp (file name).
-          required: true
-          schema:
-            type: integer
-            minimum: 0
-      security:
-        - main_auth:
-          - 'read:image'
-      responses:
-        '200':
-          description: Success
-          content:
-            image/gif:
-              schema:
-                description: Returns a GIF
-                type: string
-                format: binary
-            image/jpeg:
-              schema:
-                description: Returns a JPEG
-                type: string
-                format: binary
-            image/png:
-              schema:
-                description: Returns a PNG
-                type: string
-                format: binary
-            image/tiff:
-              schema:
-                description: Returns a TIFF
-                type: string
-                format: binary
 
 # An object to hold reusable parts that can be used across the spec
 components:
@@ -169,9 +117,7 @@ components:
       type: object
       properties:
         id:
-          description: Post unique identifier
-          type: integer
-          example: 123
+          $ref: '#/components/schemas/Uuid'
         author:
           $ref: '#/components/schemas/User'
         time:
@@ -182,7 +128,9 @@ components:
           description: Images contained within post
           type: array
           items:
-            $ref: '#/components/schemas/Image'
+            description: Image URL
+            type: string
+            minLength: 1
         likedBy:
           description: Ids of users who liked the post
           type: array
@@ -209,14 +157,11 @@ components:
       type: object
       properties:
         id:
-          description: Unique identifier for the user
-          type: integer
-          minLength: 1
+          $ref: '#/components/schemas/Uuid'
         email:
           $ref: '#/components/schemas/Email'
         avatar:
-          description: URL to user's avatar
-          type: string
+          $ref: '#/components/schemas/Avatar'
         likedPosts:
           description: Ids of posts which the user liked
           type: array
@@ -225,23 +170,23 @@ components:
             minimum: 1
       required:
         - id
+        - likedPosts
 
     Email:
       description: Email address
       type: string
       minLength: 4
       example: john.smith@example.com
-
-    Image:
-      description: |
-        Upon uploading the image to the server, the image file is renamed to the
-        format of `{userId}-{timestamp}.{ext}`. This allows us, if needed, to
-        wipe all of the data of a user should he or she desire to do so.
-      type: object
-      properties:
-        fileName:
-          type: string
-          minLength: 3
+    
+    Avatar:
+      description: URL to user's avatar
+      type: string
+      format: uri
+    
+    Uuid:
+      description: Unique identifier
+      type: integer
+      minimum: 1
 
   # Security scheme definitions that can be used across the specification.
   securitySchemes:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,249 +1,267 @@
-# This is an **example** API to demonstrate features of OpenAPI specification.
-# It doesn't cover all OpenAPI features. For more full example check out: https://github.com/APIs-guru/petstore_extended
-
 openapi: 3.0.0
 info:
-  version: '1.0.0' # Your API version
-  # It can be any string but it is better to use semantic versioning: http://semver.org/
-  # Warning: OpenAPI require version to be string, but without quotation YAML can recognize it as number.
+  version: '0.1.0'
   
-  title: Example.com # Replace with your API title
-  # Keep it simple. Don't add "API" or version at the end of the string.
+  title: 'UCLCSSA'
 
-  termsOfService: 'https://example.com/terms/' # [Optional] Replace with an URL to your ToS
-  contact:
-    email: contact@example.com # [Optional] Replace with your contact email
-    url: 'http://example.com/contact' # [Optional] Replace with link to your contact form
+  termsOfService: 'https://github.com/UCLCSSA/UCLCSSA-API/blob/master/TOS.md'
   license:
-    name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    name: 'GPL-3.0'
+    url: 'https://www.gnu.org/licenses/gpl-3.0.en.html'
   x-logo:
+    # TODO: replace logo with custom logo
     url: 'https://apis.guru/openapi-template/logo.png'
   
   # Describe your API here, you can use GFM (https://guides.github.com/features/mastering-markdown) here
   description: |
-    This is an **example** API to demonstrate features of OpenAPI specification
-    # Introduction
-    This specification is intended to to be a good starting point for describing your API in 
-    [OpenAPI/Swagger format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
-    It also demonstrates features of [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo) tool and 
-    [ReDoc](https://github.com/Rebilly/ReDoc) documentation engine. So beyond the standard OpenAPI syntax we use a few 
-    [vendor extensions](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md).
-
+    This document describes the API provided for the UCLCSSA WeChat app.
+    
     # OpenAPI Specification
-    The goal of The OpenAPI Specification is to define a standard, language-agnostic interface to REST APIs which
-    allows both humans and computers to discover and understand the capabilities of the service without access to source
-    code, documentation, or through network traffic inspection. When properly defined via OpenAPI, a consumer can 
-    understand and interact with the remote service with a minimal amount of implementation logic. Similar to what
-    interfaces have done for lower-level programming, OpenAPI removes the guesswork in calling the service.
-externalDocs:
-  description: Find out how to create Github repo for your OpenAPI spec.
-  url: 'https://github.com/Rebilly/generator-openapi-repo'
+    UCLCSSA's API is intended to conform to OpenAPI 3.0.
 
 # A list of tags used by the specification with additional metadata.
 # The order of the tags can be used to reflect on their order by the parsing tools.
 tags:
-  - name: Echo
-    description: Example echo operations
-  - name: User
-    description: Operations about user
+  - name: Posts
+    description: Operations for user posts (could be used for post feed).
+  - name: Images
+    description: Operations for uploaded images.
 servers:
-  - url: 'http://example.com/api/v1'
-  - url: 'https://example.com/api/v1'
+  - url: 'https://www.uclcssa.com/api'
 
 # Holds the relative paths to the individual endpoints. The path is appended to the
 # basePath in order to construct the full URL. 
 paths:
-  '/users/{username}': # path parameter in curly braces
-
-    # parameters list that are used with each operation for this path
-    parameters:
-      - name: pretty_print
-        in: query
-        description: Pretty print response
-        schema:
-          type: boolean
-    get: # documentation for GET operation for this path
+  '/posts':
+  
+    get:
       tags:
-        - User
-      
-      # summary is up to 120 symbold but we recommend to be shortest as possible
-      summary: Get user by user name
-      
-      # you can use GFM in operation description too: https://guides.github.com/features/mastering-markdown
+        - Posts
+      summary: Get a collection of posts (a feed).
       description: |
-        Some description of the operation. 
-        You can use `markdown` here.
-      
-      # operationId should be unique across the whole specification
-      operationId: getUserByName
-      
-      # list of parameters for the operation
+        Retrieves a collection of posts, can be used to build a feed. By default
+        only the most recent 20 posts are returned, unless `offset` and 
+        `limit` is specified. Note that the maximum posts returned at 
+        once is capped at 100.
+      operationId: getPosts
       parameters:
-        - name: username
-          in: path
-          description: The name that needs to be fetched
-          required: true
-          schema:
-            type: string
-        - name: with_email
+        - name: offset
           in: query
-          description: Filter users without email
+          description: Starting post `id` to start fetch from (inclusive).
+          required: false
           schema:
-            type: boolean
-      
-      # security schemas applied to this operation
+            type: integer
+            minimum: 1
+        - name: limit
+          in: query
+          description: Number of posts to return starting from `id`.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
       security:
         - main_auth:
-            - 'read:users' # for auth2 provide list of scopes here
-        - api_key: []
-      responses: # list of responses
+            - 'read:posts'
+      responses:
         '200':
           description: Success
           content:
-            application/json: # operation response mime type
-              schema: # response schema can be specified for each response
-                $ref: '#/components/schemas/User'
-              example: # response example
-                username: user1
-                email: user@example.com
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Posts'
         '403':
-          description: Forbidden
-        '404':
-          description: User not found
-    # documentation for PUT operation for this path
-    put:
+          description: Access forbidden
+
+  '/posts/{id}':
+  
+    get:
       tags:
-        - User
-      summary: Updated user
-      description: This can only be done by the logged in user.
-      operationId: updateUser
+        - Posts
+      summary: Get post by id.
+      description: |
+        Retrieves a post with a given `id`.
+      operationId: getPostById
       parameters:
-        - name: username
+        - name: id
           in: path
-          description: The name that needs to be updated
+          description: Target post `id`.
           required: true
           schema:
-            type: string
+            type: integer
+            minimum: 1
       security:
         - main_auth:
-            - 'write:users'
+            - 'read:post'
       responses:
         '200':
-          description: OK
-        '400':
-          description: Invalid user supplied
-        '404':
-          description: User not found
-      # request body documentation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/User'
-          application/xml:
-            schema:
-              $ref: '#/components/schemas/User'
-        description: Updated user object
-        required: true
-  /echo: # path parameter in curly braces
-    post: # documentation for POST operation for this path
-      tags:
-        - Echo
-      summary: Echo test
-      description: Receive the exact message you've sent
-      operationId: echo
-      security:
-        - api_key: []
-        - basic_auth: []
-      responses:
-        '200':
-          description: OK
-          # document headers for this response
-          headers:
-            X-Rate-Limit: # Header name
-              description: calls per hour allowed by the user
-              schema: # Header schema
-                type: integer
-                format: int32
-            X-Expires-After:
-              $ref: '#/components/headers/ExpiresAfter'
+          description: Success
           content:
             application/json:
               schema:
-                type: string
-              examples:
-                response:
-                  value: Hello world!
-            application/xml:
+                $ref: '#/components/schemas/Post'
+        '403':
+          description: Access forbidden
+        '404':
+          description: Post not found or no longer available
+
+  '/images/{id}/{timestamp}':
+  
+    get:
+      tags:
+        - Images
+      summary: Get image by user ID and timestamp (as file name).
+      parameters:
+        - name: id
+          in: path
+          description: Image uploader (owner).
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+        - name: timestamp
+          in: path
+          description: Image timestamp (file name).
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+      security: 
+        - main_auth:
+          - 'read:image'
+      responses:
+        '200':
+          description: Success
+          content:
+            image/gif:
               schema:
+                description: Returns a GIF
                 type: string
-            text/csv:
+                format: binary
+            image/jpeg:
               schema:
+                description: Returns a JPEG
                 type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-              example: Hello world!
-          application/xml:
-            schema:
-              type: string
-              example: Hello world!
-        description: Echo payload
-        required: true
-        
+                format: binary
+            image/png:
+              schema:
+                description: Returns a PNG
+                type: string
+                format: binary
+            image/tiff:
+              schema:
+                description: Returns a TIFF
+                type: string
+                format: binary
+
 # An object to hold reusable parts that can be used across the spec
 components:
   schemas:
-    Email:
-      description: User email address
-      type: string
-      format: test
-      example: john.smith@example.com
+    Posts:
+      type: object
+      properties:
+        data:
+          description: List of posts
+          type: array
+          items:
+            $ref: '#/components/schemas/Post'
+      required: 
+        - data
+    
+    Post:
+      type: object
+      properties:
+        id:
+          description: Post unique identifier
+          type: integer
+          example: 123
+        author:
+          $ref: '#/components/schemas/User'
+        time:
+          description: Post timestamp (see [RFC3339](https://tools.ietf.org/html/rfc3339))
+          type: integer
+          minimum: 0
+        images:
+          description: Images contained within post
+          type: array
+          items:
+            $ref: '#/components/schemas/Image'
+        likedBy:
+          description: Ids of users who liked the post
+          type: array
+          items:
+            type: integer
+            minimum: 1
+        category:
+          description: Category of post
+          type: string
+          example: accomodation
+        content:
+          description: Post content
+      required: 
+        - id
+        - author
+        - time
+        - images
+        - likedBy
+        - category
+          
     User:
       type: object
       properties:
-        username:
-          description: User supplied username
-          type: string
-          minLength: 4
-          example: John78
-        firstName:
-          description: User first name
-          type: string
+        id:
+          description: Unique identifier for the user
+          type: integer
           minLength: 1
-          example: John
-        lastName:
-          description: User last name
-          type: string
-          minLength: 1
-          example: Smith
         email:
           $ref: '#/components/schemas/Email'
-  headers:
-    ExpiresAfter:
-      description: date in UTC when token expires
-      schema:
-        type: string
-        format: date-time
+        avatar:
+          description: URL to user's avatar
+          type: string
+        likedPosts:
+          description: Ids of posts which the user liked
+          type: array
+          items: 
+            type: integer
+            minimum: 1
+      required: 
+        - id
+    
+    Email:
+      description: Email address
+      type: string
+      minLength: 4
+      example: john.smith@example.com
+    
+    Image:
+      description: |
+        Upon uploading the image to the server, the image file is renamed to the
+        format of `{userId}-{timestamp}.{ext}`. This allows us, if needed, to 
+        wipe all of the data of a user should he or she desire to do so.
+      type: object
+      properties:
+        fileName:
+          type: string
+          pattern: '^\d+-\d+\.[a-zA-Z0-9]+$'
+          minLength: 3
+  
   # Security scheme definitions that can be used across the specification.
   securitySchemes:
-    main_auth: # security definition name (you can name it as you want)
-      # the following options are specific to oauth2 type
+    main_auth:
       type: oauth2 # authorization type, one of: oauth2, apiKey, http
       flows:
         implicit:
-          authorizationUrl: 'http://example.com/api/oauth/dialog'
+          authorizationUrl: 'http://www.uclcssa.cn/api/oauth/dialog'
           scopes:
-            'read:users': read users info
+            'read:post': read individual post
+            'write:post': modify or remove individual post
+            'read:posts': read posts
+            'write:posts': modify or remove posts
+            'read:user': read individual user information
+            'write:user': modify or remove individual user information
+            'read:users': read users information
             'write:users': modify or remove users
-    api_key:  # security definition name (you can name it as you want)
-      type: apiKey 
-      # The following options are specific to apiKey type
-      in: header # Where API key will be passed: header or query
-      name: api_key # API key parameter name
-    basic_auth: # security definition name (you can name it as you want)
-      type: http
-      scheme: basic
+            'read:image': read individual image
+            'write:image': modify or remove individual image
+            'read:images': read images
+            'write:images': write images

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
   version: '0.1.0'
-  
-  title: 'UCLCSSA'
+
+  title: UCLCSSA
 
   termsOfService: 'https://github.com/UCLCSSA/UCLCSSA-API/blob/master/TOS.md'
   license:
@@ -11,11 +11,11 @@ info:
   x-logo:
     # TODO: replace logo with custom logo
     url: 'https://apis.guru/openapi-template/logo.png'
-  
+
   # Describe your API here, you can use GFM (https://guides.github.com/features/mastering-markdown) here
   description: |
     This document describes the API provided for the UCLCSSA WeChat app.
-    
+
     # OpenAPI Specification
     UCLCSSA's API is intended to conform to OpenAPI 3.0.
 
@@ -30,18 +30,17 @@ servers:
   - url: 'https://www.uclcssa.com/api'
 
 # Holds the relative paths to the individual endpoints. The path is appended to the
-# basePath in order to construct the full URL. 
+# basePath in order to construct the full URL.
 paths:
   '/posts':
-  
     get:
       tags:
         - Posts
       summary: Get a collection of posts (a feed).
       description: |
         Retrieves a collection of posts, can be used to build a feed. By default
-        only the most recent 20 posts are returned, unless `offset` and 
-        `limit` is specified. Note that the maximum posts returned at 
+        only the most recent 20 posts are returned, unless `offset` and
+        `limit` is specified. Note that the maximum posts returned at
         once is capped at 100.
       operationId: getPosts
       parameters:
@@ -74,7 +73,6 @@ paths:
           description: Access forbidden
 
   '/posts/{id}':
-  
     get:
       tags:
         - Posts
@@ -106,7 +104,6 @@ paths:
           description: Post not found or no longer available
 
   '/images/{id}/{timestamp}':
-  
     get:
       tags:
         - Images
@@ -126,7 +123,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-      security: 
+      security:
         - main_auth:
           - 'read:image'
       responses:
@@ -165,9 +162,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Post'
-      required: 
+      required:
         - data
-    
+
     Post:
       type: object
       properties:
@@ -198,14 +195,16 @@ components:
           example: accomodation
         content:
           description: Post content
-      required: 
+          type: string
+      required:
         - id
         - author
         - time
         - images
         - likedBy
         - category
-          
+        - content
+
     User:
       type: object
       properties:
@@ -221,30 +220,29 @@ components:
         likedPosts:
           description: Ids of posts which the user liked
           type: array
-          items: 
+          items:
             type: integer
             minimum: 1
-      required: 
+      required:
         - id
-    
+
     Email:
       description: Email address
       type: string
       minLength: 4
       example: john.smith@example.com
-    
+
     Image:
       description: |
         Upon uploading the image to the server, the image file is renamed to the
-        format of `{userId}-{timestamp}.{ext}`. This allows us, if needed, to 
+        format of `{userId}-{timestamp}.{ext}`. This allows us, if needed, to
         wipe all of the data of a user should he or she desire to do so.
       type: object
       properties:
         fileName:
           type: string
-          pattern: '^\d+-\d+\.[a-zA-Z0-9]+$'
           minLength: 3
-  
+
   # Security scheme definitions that can be used across the specification.
   securitySchemes:
     main_auth:


### PR DESCRIPTION
Docs for initial endpoints are added:

- `GET /posts?offset={o}&limit={n}` for obtaining a feed starting at post id `o` with `n` posts per page.
- `GET /posts/{id}` for obtaining a post with given `id`.
- `GET /images/{id}/{timestamp}` for obtaining an uploaded image with file name `{id}-{timestamp}.{ext}`.